### PR TITLE
Scope the checkout summary to the signed-in user's cart

### DIFF
--- a/src/db/queries/cart.test.ts
+++ b/src/db/queries/cart.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { drizzle } from "drizzle-orm/pg-proxy";
+
+/**
+ * These tests run the real query builders against a proxy driver, so the SQL
+ * asserted on here is the SQL the action would send to Postgres. A missing
+ * `where` clause shows up as a missing predicate in the captured statement,
+ * which is exactly the failure mode being guarded against.
+ */
+
+const authMock = vi.fn();
+
+interface ExecutedQuery {
+  sql: string;
+  params: unknown[];
+}
+
+const executed: ExecutedQuery[] = [];
+
+/** Rows the driver hands back, matched by a fragment of the statement. */
+let stubbedRows: { fragment: string; rows: unknown[][] }[] = [];
+
+vi.mock("@clerk/nextjs/server", () => ({ auth: () => authMock() }));
+
+vi.mock("@/db", () => ({
+  db: drizzle(async (sql: string, params: unknown[]) => {
+    executed.push({ sql, params });
+    const stub = stubbedRows.find((candidate) =>
+      sql.includes(candidate.fragment),
+    );
+    return { rows: stub ? stub.rows : [] };
+  }),
+}));
+
+import { getCheckoutData } from "./cart";
+
+const GUEST = { id: 7, clerkId: "clerk_guest", role: "guest" as const };
+
+function signedInAs(user: typeof GUEST | null) {
+  authMock.mockReturnValue({ userId: user?.clerkId ?? null });
+  // The session lookup in requireUser() selects id, clerkId, role in that order.
+  stubbedRows = [
+    {
+      fragment: 'from "user"',
+      rows: user ? [[user.id, user.clerkId, user.role]] : [],
+    },
+  ];
+}
+
+/** The statement that reads the cart, as opposed to the session lookup. */
+function cartQuery(): ExecutedQuery | undefined {
+  return executed.find((query) => query.sql.includes('from "cart"'));
+}
+
+describe("getCheckoutData", () => {
+  beforeEach(() => {
+    authMock.mockReset();
+    executed.length = 0;
+    stubbedRows = [];
+  });
+
+  // Regression: the checkout summary used to read every row in the cart table
+  // because the query had no `where` clause. A user with one bed in their cart
+  // saw all 24 beds in the system, the names of other users' guests, and was
+  // asked to pay the sum of everybody's rent.
+  it("reads only the signed-in user's cart rows", async () => {
+    signedInAs(GUEST);
+
+    await getCheckoutData();
+
+    const query = cartQuery();
+    expect(query).toBeDefined();
+    expect(query!.sql).toContain('"cart"."user_id" =');
+    expect(query!.params).toContain(GUEST.id);
+  });
+
+  it("does not touch the cart for an anonymous caller", async () => {
+    signedInAs(null);
+
+    const result = await getCheckoutData();
+
+    expect(result.status).toBe("error");
+    expect(result.data).toBeNull();
+    expect(cartQuery()).toBeUndefined();
+  });
+});

--- a/src/db/queries/cart.ts
+++ b/src/db/queries/cart.ts
@@ -200,7 +200,7 @@ export const getCartItems = async () => {
 
 export const getCheckoutData = async () => {
   try {
-    await requireUser();
+    const user = await requireUser();
     const checkoutData = await db
       .select({
         id: CartTable.id,
@@ -213,7 +213,8 @@ export const getCheckoutData = async () => {
       })
       .from(CartTable)
       .innerJoin(GuestTable, eq(CartTable.guestId, GuestTable.id))
-      .innerJoin(BedTable, eq(CartTable.bedId, BedTable.id));
+      .innerJoin(BedTable, eq(CartTable.bedId, BedTable.id))
+      .where(eq(CartTable.userId, user.id));
 
     return { status: "success", data: checkoutData };
   } catch (error) {


### PR DESCRIPTION
## The bug

`getCheckoutData` in `src/db/queries/cart.ts` selected from the cart table with **no `where` clause**. It called `requireUser()` — confirming *someone* was signed in — and then returned every cart row in the database.

Reported from the payment step: a cart with one item showed **Total Bed(s): 24**, listed twenty-four other people's guests by first name, and asked for ₹73,199.

## Why it mattered beyond the display

- **Cross-user data leak.** Everything in `src/db/queries/` is a server action, so it is a public HTTP endpoint. Any signed-in user could call this directly and read the guest names of every other user.
- **Billing mismatch.** `createBooking` scopes its own cart read to the current user, so confirming payment would have inserted a single bed booking while writing a transaction for the sum of everybody's rent.

The cart page itself was always correct — `getCartItems` filters on `CartTable.userId` — which is why the cart showed 1 item and checkout showed 24.

## The fix

Capture the user `requireUser()` already returns and constrain the query to them:

```ts
const user = await requireUser();
...
  .where(eq(CartTable.userId, user.id));
```

## Test

`src/db/queries/cart.test.ts` runs the real query builder against a `pg-proxy` driver and asserts on the SQL that would reach Postgres — that it constrains `cart.user_id` to the session user, and that an anonymous caller never reaches the cart at all. Verified to fail against the unscoped version:

```
AssertionError: expected 'select "cart"."id", … from "cart" inner join …' to contain '"cart"."user_id" ='
```

This is the first test against `src/db/queries/`; the proxy-driver setup is reusable for the other actions.

## Checks

`pnpm lint`, `typecheck`, `check:env`, `test` (72 passing), and `build` all pass locally.

## Worth following up

Any transactions already created from this page are worth auditing against their `BedBookingTable` rows — a row whose `totalAmount` far exceeds its bed count was hit by this.